### PR TITLE
🛠️ Refactor: Extract duplicated HTTP and error handling logic

### DIFF
--- a/bruto/BRL/BR.B3/fetch
+++ b/bruto/BRL/BR.B3/fetch
@@ -1,43 +1,27 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from dataclasses import dataclass
 from enum import Enum
+import sys
 from datetime import date, datetime
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 import re
-import json
 import logging
-from urllib.request import urlopen, Request
-import functools
 from csv import DictWriter
+from dataclasses import dataclass
+
+CURRENT_DIR=Path(__file__).resolve().parent
+sys.path.append(str(CURRENT_DIR.parent.parent.parent / "src"))
+
+from core.http import fetch_body, fetch_json
+from core.models import Entry
+from core.errors import report_error
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
-CURRENT_DIR=Path(__file__).parent
 TODAY = datetime.today().date()
-
-USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0"
-
-@functools.cache
-def fetch_body(url: str, fetch_try=0):
-    """
-    Downloads raw payload from an endpoint and caches it via functools.
-    Utilizes a hardcoded browser User-Agent to mitigate 403 blocks from CDNs.
-    """
-    logger.debug(f"fetch: {url}")
-    res = urlopen(Request(url, headers={
-      "User-Agent": USER_AGENT,
-    }))
-    return res.read()
-
-def fetch_json(url: str):
-    """
-    Loads cached bytes returned by fetch_body and parses them into a Python dict.
-    """
-    return json.loads(fetch_body(url))
 
 fetchers = {}
 def fetcher(fn):
@@ -56,23 +40,6 @@ class AssetType(Enum):
 
     def __hash__(self):
         return self.value.__hash__()
-
-@dataclass
-class Entry():
-    """
-    Encapsulates a parsed daily price metric. Serves as the canonical data
-    structure emitted by any downstream scraping task.
-    """
-    day: date
-    price: float
-
-    @property
-    def columns(self):
-        return ['day', 'price']
-
-    @property
-    def line(self):
-        return {"day": str(self.day), "price": self.price}
 
 @dataclass
 class Job():
@@ -135,7 +102,7 @@ def handle_job(job: Job):
     try:
         return fetchers[job.source](job)
     except Exception as e:
-        logger.error(e)
+        report_error(e, context={"job": job})
         return Result(job=job, entry=None)
 
 def get_jobs():

--- a/bruto/BRL/BR.TesouroDireto/fetch
+++ b/bruto/BRL/BR.TesouroDireto/fetch
@@ -1,45 +1,21 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from dataclasses import dataclass
+import sys
 from datetime import date, datetime
-import json
 import logging
-from urllib.request import urlopen, Request
-import functools
 from csv import DictWriter
+
+CURRENT_DIR=Path(__file__).resolve().parent
+sys.path.append(str(CURRENT_DIR.parent.parent.parent / "src"))
+
+from core.http import fetch_json
+from core.models import Entry
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
-CURRENT_DIR=Path(__file__).parent
 TODAY = datetime.today().date()
-
-USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0"
-
-@functools.cache
-def fetch_body(url: str, fetch_try=0):
-    logger.debug(f"fetch: {url}")
-    res = urlopen(Request(url, headers={
-      "User-Agent": USER_AGENT,
-    }))
-    return res.read()
-
-def fetch_json(url: str):
-    return json.loads(fetch_body(url))
-
-@dataclass
-class Entry():
-    day: date
-    price: float
-
-    @property
-    def columns(self):
-        return ['day', 'price']
-
-    @property
-    def line(self):
-        return {"day": str(self.day), "price": self.price}
 
 content = fetch_json("https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json")
 items = [item['TrsrBd'] for item in content['response']['TrsrBdTradgList']]

--- a/bruto/USD/ETF/fetch
+++ b/bruto/USD/ETF/fetch
@@ -1,45 +1,27 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from dataclasses import dataclass
 from enum import Enum
+import sys
 from datetime import date, datetime
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 import re
-import json
 import logging
-from urllib.request import urlopen, Request
-import functools
 from csv import DictWriter
+from dataclasses import dataclass
+
+CURRENT_DIR=Path(__file__).resolve().parent
+sys.path.append(str(CURRENT_DIR.parent.parent.parent / "src"))
+
+from core.http import fetch_body, fetch_json
+from core.models import Entry
+from core.errors import report_error
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
-CURRENT_DIR=Path(__file__).parent
 TODAY = datetime.today().date()
-
-USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0"
-
-@functools.cache
-def fetch_body(url: str, fetch_try=0):
-    """
-    Fetches raw body content from a URL, spoofing a standard browser user agent
-    to avoid basic bot protections. Caches results in memory to prevent duplicate
-    network requests for the same URL during a single script execution.
-    """
-    logger.debug(f"fetch: {url}")
-    res = urlopen(Request(url, headers={
-      "User-Agent": USER_AGENT,
-    }))
-    return res.read()
-
-def fetch_json(url: str):
-    """
-    Wraps fetch_body to directly decode the fetched payload as JSON.
-    Benefits from the underlying memory cache in fetch_body.
-    """
-    return json.loads(fetch_body(url))
 
 fetchers = {}
 def fetcher(fn):
@@ -56,23 +38,6 @@ class AssetType(Enum):
 
     def __hash__(self):
         return self.value.__hash__()
-
-@dataclass
-class Entry():
-    """
-    Represents a single scraped data point for a ticker. Designed
-    to map easily to a CSV row format representing time series data.
-    """
-    day: date
-    price: float
-
-    @property
-    def columns(self):
-        return ['day', 'price']
-
-    @property
-    def line(self):
-        return {"day": str(self.day), "price": self.price}
 
 @dataclass
 class Job():
@@ -127,7 +92,7 @@ def handle_job(job: Job):
     try:
         return fetchers[job.source](job)
     except Exception as e:
-        logger.error(e)
+        report_error(e, context={"job": job})
         return Result(job=job, entry=None)
 
 def get_jobs():

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -1,0 +1,14 @@
+import logging
+
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
+
+def report_error(e: Exception, context: dict = None):
+    """
+    Centralized error reporting function.
+    All code paths that handle unexpected errors MUST funnel through this function.
+    """
+    error_msg = f"Unexpected error occurred: {e}"
+    if context:
+        error_msg += f" | Context: {context}"
+    logger.error(error_msg, exc_info=True)

--- a/src/core/http.py
+++ b/src/core/http.py
@@ -1,0 +1,29 @@
+import json
+import logging
+from urllib.request import urlopen, Request
+import functools
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0"
+
+@functools.cache
+def fetch_body(url: str, fetch_try=0):
+    """
+    Fetches raw body content from a URL, spoofing a standard browser user agent
+    to avoid basic bot protections. Caches results in memory to prevent duplicate
+    network requests for the same URL during a single script execution.
+    """
+    logger.debug(f"fetch: {url}")
+    res = urlopen(Request(url, headers={
+      "User-Agent": USER_AGENT,
+    }))
+    return res.read()
+
+def fetch_json(url: str):
+    """
+    Wraps fetch_body to directly decode the fetched payload as JSON.
+    Benefits from the underlying memory cache in fetch_body.
+    """
+    return json.loads(fetch_body(url))

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from datetime import date
+
+@dataclass
+class Entry:
+    """
+    Represents a single scraped data point for a ticker. Designed
+    to map easily to a CSV row format representing time series data.
+    """
+    day: date
+    price: float
+
+    @property
+    def columns(self):
+        return ['day', 'price']
+
+    @property
+    def line(self):
+        return {"day": str(self.day), "price": self.price}


### PR DESCRIPTION
### Assumptions
- It's safe to load shared library modules from `src/core` dynamically via `sys.path.append(str(CURRENT_DIR.parent.parent.parent / "src"))` from the individual scrapers.
- The default browser `USER_AGENT` defined in `src/core/http.py` will continue to safely apply to all downstream fetching scripts needing spoofing without conflict.
- The `Entry` dataclass can be shared across B3, ETF, and Tesouro Direto scripts without requiring disparate fields across domains at this time.

### Alternatives Not Chosen
- We could have converted the repository into an installable python package or required running from a centralized bootstrap script (e.g. `python -m src.bruto.BRL...`) instead of the `sys.path.append` injection in individual scripts. This was rejected because the existing setup already heavily relies on executing discrete `fetch` binaries from various shell scripts (e.g., `find -type f -executable -name fetch`), so we preserved the existing interface.
- We could have added Sentry SDK for error logging, but the global instructions specify that we should stick to logging context via the centralized function if no explicit backend is predefined. We've utilized standard `logging`.

### How To Pivot
If the central `src/core` models become too restrictive for future scrapers that need entirely different HTTP caching rules or data columns, we can abstract `Entry` into a base protocol class (e.g., `typing.Protocol`) and extract specific subclasses for complex assets while retaining the shared network cache.

### Next Knobs
- **`src/core/errors.py`:** Add Sentry hooks or Slack webhook notifications inside `report_error`.
- **`src/core/http.py`:** Extract the hardcoded `USER_AGENT` to an environment variable (`os.getenv("USER_AGENT")`) to dynamically rotate it from CI/CD.
- **`src/core/models.py`:** Parameterize `columns` output for the `Entry` class if different asset classes start requiring varied CSV headers.

---
*PR created automatically by Jules for task [11599919279418108334](https://jules.google.com/task/11599919279418108334) started by @lucasew*