### PR TITLE
🛡️ Sentinel: [MEDIUM] Centralize error reporting for exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-15: [Medium] Ignored/swallowed errors via non-centralized logger calls in catch blocks.

--- a/bruto/BRL/BR.B3/fetch
+++ b/bruto/BRL/BR.B3/fetch
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from datetime import date, datetime
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Optional
 import re
 import json
@@ -12,6 +13,11 @@ import logging
 from urllib.request import urlopen, Request
 import functools
 from csv import DictWriter
+import sys
+
+# Dynamically append the src directory to sys.path to import core shared logic
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent.parent / 'src'))
+from core.errors import report_error
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -135,7 +141,7 @@ def handle_job(job: Job):
     try:
         return fetchers[job.source](job)
     except Exception as e:
-        logger.error(e)
+        report_error(e, context={"job": job})
         return Result(job=job, entry=None)
 
 def get_jobs():

--- a/bruto/USD/ETF/fetch
+++ b/bruto/USD/ETF/fetch
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from datetime import date, datetime
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Optional
 import re
 import json
@@ -12,6 +13,11 @@ import logging
 from urllib.request import urlopen, Request
 import functools
 from csv import DictWriter
+import sys
+
+# Dynamically append the src directory to sys.path to import core shared logic
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent.parent / 'src'))
+from core.errors import report_error
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -127,7 +133,7 @@ def handle_job(job: Job):
     try:
         return fetchers[job.source](job)
     except Exception as e:
-        logger.error(e)
+        report_error(e, context={"job": job})
         return Result(job=job, entry=None)
 
 def get_jobs():

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -1,0 +1,13 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def report_error(e: Exception, context: dict = None):
+    """
+    Centralized error reporting function.
+    Logs the exception with optional context.
+    """
+    if context:
+        logger.error(f"Error occurred: {e} | Context: {context}", exc_info=True)
+    else:
+        logger.error(f"Error occurred: {e}", exc_info=True)


### PR DESCRIPTION
### Vulnerability
Medium severity: Ignored or swallowed errors inside `fetch` scripts masking underlying scraping failures. The original code used `logger.error(e)` but lacked context and did not route through a centralized error tracking mechanism.

### Impact
When API responses change or structural shifts occur in scraped websites, exceptions get lost in console logs. This masks bugs downstream, violating the centralized error reporting directive and making debugging silent failures extremely difficult. 

### Fix
Created `src/core/errors.py` providing a generic `report_error` logging function. Migrated the catch blocks in `bruto/BRL/BR.B3/fetch` and `bruto/USD/ETF/fetch` to dynamically append `src` to `sys.path` and use this central function with explicit tracebacks (`exc_info=True`) and attached job context. Added a note to `.jules/sentinel.md` capturing the pattern of swallowed errors. 

### Verification
Manual execution of `python3 bruto/BRL/BR.B3/fetch` confirmed that 403 Forbidden errors are correctly routed to the new central handler, injecting `context` safely into the standard python logger traceback. 

### Assumptions
- Python `fetch` scripts are invoked standalone, so dynamic `sys.path` appending based on directory depth is appropriate. 
- A basic standard `logging` implementation is sufficient for the central function until `sentry-sdk` is explicitly requested by the project. 

### Alternatives Not Chosen
- Adding Sentry integration: Skipped as Sentry is not currently set up in the project, deferring to the fallback behavior (standard logger with context).
- Setting up a package config (e.g. `setup.py` / `pyproject.toml`) for imports: Too wide in scope for a Sentinel agent fix. Dynamic `sys.path` injection keeps the diff minimal and scoped.

### How To Pivot
If a proper package setup is preferred instead of dynamic `sys.path` injection, remove the `sys.path.append(...)` lines and rely on a virtual environment that installs `src` as a package. 

### Next Knobs
- **Sentry Integration:** Replace `logger.error` in `src/core/errors.py` with `sentry_sdk.capture_exception` if Sentry DSNs are provisioned. 
- **Refactoring other scripts:** Extend this fix to the remaining `fetch` scripts in `BR.CDI` if they start handling complex requests or threaded pools.

---
*PR created automatically by Jules for task [3814673725222137463](https://jules.google.com/task/3814673725222137463) started by @lucasew*