### PR TITLE
🛡️ Sentinel: [CRITICAL] Annotate hardcoded dummy password in cetip fetch script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-03-21: [Critical] Look for intentional dummy passwords used in rclone configurations and ensure they are annotated.

--- a/bruto/BR.CDI/cetip/fetch
+++ b/bruto/BR.CDI/cetip/fetch
@@ -20,6 +20,7 @@ args = parser.parse_args()
 RCLONE_BIN = which("rclone")
 assert RCLONE_BIN is not None, "rclone não instalado" # TODO: baixar o binário na hora
 
+# SECURITY-NOTE: Intentional dummy password for anonymous FTP.
 # gerado com `rclone obscure dummy`
 RCLONE_DUMMY_ENCODED_PASSWORD = "RhNsirK9BpdNF7jZBMv0eumRZhZU"
 


### PR DESCRIPTION
**Severity**: Critical (Hardcoded Credentials)
**Vulnerability**: The script `bruto/BR.CDI/cetip/fetch` contains a hardcoded variable `RCLONE_DUMMY_ENCODED_PASSWORD`. Even though context indicates it's meant as a dummy for an anonymous FTP connection, unannotated secrets directly in the source tree violate standard security policy and trigger automated alerts.
**Impact**: None currently, as the credential is a dummy password meant for a public anonymous FTP server, but leaving it unannotated sets a bad precedent and creates noise for credential scanners.
**Fix**: Appended `# SECURITY-NOTE: Intentional dummy password for anonymous FTP.` directly above the variable to explicitly mark it as a known, intentional non-secret. Initialized the Sentinel journal at `.jules/sentinel.md` with the recognized pattern.
**Verification**: Verified visually. `mise run test` was skipped because the repository (on main) currently lacks `.mise.toml` or tests.

## Assumptions
- The password is truly a dummy password meant for the public CETIP FTP, as the `rclone obscure dummy` comment implies.

## Alternatives Not Chosen
- Deleting the password and removing the `pass=` argument from the `rclone` call. Some FTP servers require a password (even an arbitrary one) when logging in as `anonymous`. Rather than risk breaking the script, I annotated it.

## How To Pivot
- If the password shouldn't be there at all, remove the `# SECURITY-NOTE`, the `RCLONE_DUMMY_ENCODED_PASSWORD` assignment, and strip `pass={RCLONE_DUMMY_ENCODED_PASSWORD}` from the `rclone_args` list in `bruto/BR.CDI/cetip/fetch`.

## Next Knobs
- Adjusting `rclone_args` to fetch via environment variable if real authentication is ever needed for the CETIP FTP server.

---
*PR created automatically by Jules for task [8068508771971068114](https://jules.google.com/task/8068508771971068114) started by @lucasew*